### PR TITLE
Allow build outside of source tree

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -24,12 +24,12 @@ source   =
 header   = 
 document = QUICKSTART QUICKSTART.jp
 sample   = 
-MANPAGES = $(patsubst %.1.in, %.1, $(wildcard *.1.in))
+MANPAGES = $(patsubst $(srcdir)/%.1.in, %.1, $(wildcard $(srcdir)/*.1.in))
 
 DISTDIR = $(top_srcdir)/`cat $(top_srcdir)/distdir`
 DISTFILES = Makefile.in \
 	$(header) $(source) \
-	$(document) $(sample)
+	$(srcdir)/$(document) $(sample)
 DISTFILES += $(MANPAGES)
 
 #########################################################################
@@ -40,7 +40,7 @@ all: $(MANPAGES)
 $(MANPAGES):
 	$(SED) -e 's:%%PREFIX%%:$(prefix):g' \
 		-e 's:%%CONFIGDIR%%:$(configdir):g' \
-		-e 's:%%MEDIADIR%%:$(mediadir):g' < $(patsubst %.1, %.1.in, $@) > $@
+		-e 's:%%MEDIADIR%%:$(mediadir):g' < $(patsubst %.1, $(srcdir)/%.1.in, $@) > $@
 
 dist: $(DISTFILES)
 	$(MKDIR_P) $(DISTDIR)/$(subdir)

--- a/etc/Makefile.in
+++ b/etc/Makefile.in
@@ -44,17 +44,17 @@ all: istgt.large.conf istgt.conf $(rcfile)
 istgt.large.conf:
 	$(SED) -e 's:%%SYSCONFDIR%%:$(sysconfdir):g' \
 		-e 's:%%CONFIGDIR%%:$(configdir):g' \
-		-e 's:%%MEDIADIR%%:$(mediadir):g' < istgt.large.conf.in > $@
+		-e 's:%%MEDIADIR%%:$(mediadir):g' < $(srcdir)/istgt.large.conf.in > $@
 istgt.conf:
 	$(SED) -e 's:%%SYSCONFDIR%%:$(sysconfdir):g' \
 		-e 's:%%CONFIGDIR%%:$(configdir):g' \
-		-e 's:%%MEDIADIR%%:$(mediadir):g' < istgt.conf.in > $@
+		-e 's:%%MEDIADIR%%:$(mediadir):g' < $(srcdir)/istgt.conf.in > $@
 $(rcfile):
 	$(SED) -e 's:%%SYSCONFDIR%%:$(sysconfdir):g' \
 		-e 's:%%CONFIGDIR%%:$(configdir):g' \
 		-e 's:%%MEDIADIR%%:$(mediadir):g' \
 		-e 's:%%BINDIR%%:$(bindir):g' \
-		-e 's:%%SBINDIR%%:$(sbindir):g' < $(rctemplate) > $@
+		-e 's:%%SBINDIR%%:$(sbindir):g' < $(srcdir)/$(rctemplate) > $@
 
 .PHONY: dist clean distclean depend
 dist: $(DISTFILES)
@@ -68,8 +68,8 @@ install: install-dirs
 	$(INSTALL) -m 0644 istgt.conf $(DESTDIR)$(sysconfdir)/istgt/istgt.conf.sample
 	$(INSTALL) -m 0644 istgt.large.conf \
 		$(DESTDIR)$(sysconfdir)/istgt/istgt.large.conf.sample
-	$(INSTALL) -m 0600 auth.conf $(DESTDIR)$(sysconfdir)/istgt/auth.conf.sample
-	$(INSTALL) -m 0600 istgtcontrol.conf \
+	$(INSTALL) -m 0600 $(srcdir)/auth.conf $(DESTDIR)$(sysconfdir)/istgt/auth.conf.sample
+	$(INSTALL) -m 0600 $(srcdir)/istgtcontrol.conf \
 		$(DESTDIR)$(sysconfdir)/istgt/istgtcontrol.conf.sample
 	if [ "x$(rcfile)" != "x" -a -f "$(rcfile)" ]; then \
 	    if  [ "x$(rcfile)" == "xistgt.service" ]; then \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -17,7 +17,7 @@ mandir   = @mandir@
 
 CC       = @CC@
 CFLAGS   = @CFLAGS@ @ELASTO@
-CPPFLAGS = @CPPFLAGS@ -I$(top_srcdir) -I$(srcdir)
+CPPFLAGS = @CPPFLAGS@ -I$(top_srcdir) -I$(srcdir) -I. -I./src
 LDFLAGS  = @LDFLAGS@
 DEFS     = @DEFS@
 LIBS     = @LIBS@ @ELASTO@
@@ -70,13 +70,14 @@ DISTEXTVER = `sed -e '/ISTGT_EXTRA_VERSION/!d' -e 's/[^0-9.]*\([0-9.a-z]*\).*/\1
 DISTDIR = $(top_srcdir)/`cat $(top_srcdir)/distdir`
 DISTNAME = $(DISTDIR).tar.gz
 DISTFILES = Makefile.in config.h.in build.h.in \
-	$(header) $(source) $(ctl_header) $(ctl_source) \
+	$(header) $(addprefix $(srcdir)/,$(source)) \
+	$(ctl_header) $(addprefix $(srcdir)/,$(ctl_source)) \
 	$(document) $(sample)
 
 #########################################################################
 
 .SUFFIXES: .c .o
-.c.o:
+%.o:	$(srcdir)/%.c
 	$(CC) $(DEFS) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
 .PHONY: all install install-dirs
@@ -107,7 +108,7 @@ dist: $(DISTFILES)
 
 depend:
 	if [ "x$(MKDEP)" != "x" ]; then \
-		$(MKDEP) -MM $(DEFS) $(CFLAGS) $(CPPFLAGS) $(source); \
+		$(MKDEP) -MM $(DEFS) $(CFLAGS) $(CPPFLAGS) $(addprefix $(srcdir)/,$(source)); \
 	fi
 	touch stamp-depend
 


### PR DESCRIPTION
Allow `./configure`, `make`, and `make install` to be run from a working directory outside the source tree. Reviews welcome, as I only tested a standard build on macOS. Have not tested `--with-vbox=`, `--with-vboxlib=`, or `--with-elasto` options.
